### PR TITLE
Do not send an empty diagnostics capability.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -61,7 +61,6 @@ const clientCapabilities: lsp.ClientCapabilities = {
     implementation: {},
     typeDefinition: {},
     references: {},
-    diagnostic: {},
   },
   window: {
     showMessage: {}


### PR DESCRIPTION
This appears to confuse some LSPs such as ruff.