### PR TITLE
Update `$/cancelRequest` to send object

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -428,7 +428,7 @@ export class LSPClient {
   /// (which is compared by identity).
   cancelRequest(params: any) {
     let found = this.requests.find(r => r.params === params)
-    if (found) this.notification("$/cancelRequest", found.id)
+    if (found) this.notification("$/cancelRequest", {id: found.id})
   }
 
   /// @internal


### PR DESCRIPTION
I am not sure the code formatting that you prefer, I learned from the following existed code:

```ts
this.notification<lsp.DidCloseTextDocumentParams>("textDocument/didClose", {textDocument: {uri}})
```

---

This fix addresses the LSP:

```ts
interface CancelParams {
	/**
	 * The request id to cancel.
	 */
	id: integer | string;
}
```

See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#cancelRequest