### PR TITLE
Add support for code highlighting using semantic tokens

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import type * as lsp from "vscode-languageserver-protocol"
-import {showDialog} from "@codemirror/view"
+import {SemanticTokenTypes, SemanticTokenModifiers} from "vscode-languageserver-protocol"
+import {Decoration, showDialog} from "@codemirror/view"
 import {ChangeSet, ChangeDesc, MapMode, Text, Extension} from "@codemirror/state"
 import {Language} from "@codemirror/language"
 import {LSPPlugin, lspPlugin} from "./plugin"
@@ -62,6 +63,16 @@ const clientCapabilities: lsp.ClientCapabilities = {
     typeDefinition: {},
     references: {},
     diagnostic: {},
+    semanticTokens: {
+      requests: {
+        full: true,
+        range: true,
+      },
+      tokenTypes: Object.values(SemanticTokenTypes),
+      tokenModifiers: Object.values(SemanticTokenModifiers),
+      formats: ["relative"],
+      overlappingTokenSupport: true,
+    }
   },
   window: {
     showMessage: {}
@@ -187,6 +198,16 @@ export type LSPClientConfig = {
   /// function here that returns a CodeMirror language object for a
   /// given language tag to support more languages.
   highlightLanguage?: (name: string) => Language | null
+  /// A callback to opt into highlighting code using 
+  /// `textDocument/semanticTokens` requests. Will be called for every
+  /// token to decide how exactly it should be highlighted.
+  highlightSemanticTokens?: (
+    plugin: LSPPlugin,
+    from: number,
+    to: number,
+    tokenType: SemanticTokenTypes | string,
+    tokenModifiers: (SemanticTokenModifiers | string)[],
+  ) => Decoration
   /// By default, the client will only handle the server notifications
   /// `window/logMessage` (logging warnings and errors to the console)
   /// and `window/showMessage`. You can pass additional handlers here.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {signatureHelp, nextSignature, prevSignature, showSignatureHelp, signatur
 export {jumpToDefinition, jumpToDeclaration, jumpToTypeDefinition, jumpToImplementation, jumpToDefinitionKeymap} from "./definition"
 export {findReferences, closeReferencePanel, findReferencesKeymap} from "./references"
 export {serverDiagnostics} from "./diagnostics"
+export {semanticTokens} from "./semanticTokens"
 
 import {Extension} from "@codemirror/state"
 import {keymap} from "@codemirror/view"
@@ -22,6 +23,7 @@ import {signatureHelp} from "./signature"
 import {jumpToDefinitionKeymap} from "./definition"
 import {findReferencesKeymap} from "./references"
 import {serverDiagnostics} from "./diagnostics"
+import {semanticTokens} from "./semanticTokens"
 
 /// Returns an extension that enables the [LSP
 /// plugin](#lsp-client.LSPPlugin) as well as LSP based
@@ -40,6 +42,7 @@ export function languageServerSupport(client: LSPClient, uri: string, languageID
     hoverTooltips(),
     keymap.of([...formatKeymap, ...renameKeymap, ...jumpToDefinitionKeymap, ...findReferencesKeymap]),
     signatureHelp(),
+    semanticTokens(),
   ]
 }
 
@@ -53,6 +56,7 @@ export function languageServerExtensions(): readonly (Extension | LSPClientExten
     hoverTooltips(),
     keymap.of([...formatKeymap, ...renameKeymap, ...jumpToDefinitionKeymap, ...findReferencesKeymap]),
     signatureHelp(),
-    serverDiagnostics()
+    serverDiagnostics(),
+    semanticTokens(),
   ]
 }

--- a/src/semanticTokens.ts
+++ b/src/semanticTokens.ts
@@ -1,0 +1,160 @@
+import type * as lsp from "vscode-languageserver-protocol"
+import {StateField, StateEffect, Extension, RangeSetBuilder} from "@codemirror/state"
+import {EditorView, ViewPlugin, ViewUpdate, DecorationSet, Decoration} from "@codemirror/view"
+import {LSPPlugin} from "./plugin"
+import {toPosition} from "./pos"
+
+const debounceTimeMs: number = 100
+
+const semanticTokensPlugin = ViewPlugin.fromClass(class {
+  debounceTimer: number = 0
+  pendingRequest: Promise<lsp.SemanticTokens | null> | null = null
+
+  update(update: ViewUpdate): void {
+    const plugin = LSPPlugin.get(update.view)
+    if (!plugin) return
+
+    if (!plugin.client.config.highlightSemanticTokens) return
+
+    const semanticTokensProvider = plugin.client.serverCapabilities?.semanticTokensProvider
+    if (!semanticTokensProvider) return
+    if (!semanticTokensProvider.full && !semanticTokensProvider.range)  return
+
+    const state = update.view.state.field(semanticTokensState)
+    if (state == null) {
+      this.startRequest(plugin, update.view)
+      return
+    }
+
+    if (!update.docChanged) return
+
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    this.debounceTimer = setTimeout(() => {
+      if (this.debounceTimer) clearTimeout(this.debounceTimer)
+      this.startRequest(plugin, update.view)
+    }, debounceTimeMs)
+  }
+
+  startRequest(plugin: LSPPlugin, view: EditorView): void {
+    if (this.pendingRequest != null) {
+      // There is a pending request on an older document state that should
+      // be cancelled here.
+    }
+
+    plugin.client.sync()
+
+    const supportRangeRequest = !!plugin.client.serverCapabilities?.semanticTokensProvider?.range
+    const promise = supportRangeRequest ? 
+      plugin.client.request<lsp.SemanticTokensRangeParams, lsp.SemanticTokens | null>("textDocument/semanticTokens/range", {
+        textDocument: {uri: plugin.uri},
+        range: {
+          start: {line: 0, character: 0},
+          end: toPosition(view.state.doc, view.state.doc.length),
+        },
+      })
+      : plugin.client.request<lsp.SemanticTokensParams, lsp.SemanticTokens | null>("textDocument/semanticTokens/full", {
+        textDocument: {uri: plugin.uri},
+      })
+    this.pendingRequest = promise
+    promise.then((data) => {
+      if (this.pendingRequest == promise) {
+        this.pendingRequest = null
+        this.handleResponse(data, plugin, view)
+      }
+    }).catch((err) => {
+      if (this.pendingRequest == promise) {
+        this.pendingRequest = null
+      }
+      if ("code" in err && (err as lsp.ResponseError).code == -32800 /* RequestCancelled */)
+        return
+      throw err
+    })
+  }
+
+  handleResponse(
+    semanticTokens: lsp.SemanticTokens | null, 
+    plugin: LSPPlugin, 
+    view: EditorView,
+  ): void {
+    if (!semanticTokens) return
+    if (semanticTokens.data.length % 5) return
+
+    const semanticTokensProvider = plugin.client.serverCapabilities?.semanticTokensProvider!
+    const tokenTypeLegend = semanticTokensProvider.legend.tokenTypes
+    const tokenModifierLegend = semanticTokensProvider.legend.tokenModifiers
+    
+    const builder = new RangeSetBuilder<Decoration>()
+
+    let lineStart = 0
+    let line = 0
+    let character = 0
+
+    const data = semanticTokens.data
+    for (let i = 0; i < data.length; i += 5) {
+      const deltaLine = data[i]
+      const deltaStartChar = data[i + 1]
+      const length = data[i + 2]
+      const tokenType = data[i + 3]
+      const tokenModifierBitSet = data[i + 4]
+
+      line += deltaLine
+      if (deltaLine != 0) {
+        lineStart = view.state.doc.line(line + 1).from
+        character = 0
+      }
+      character += deltaStartChar
+
+      let modifiers = []
+      let value = tokenModifierBitSet
+      let index = 0
+      while (value != 0) {
+        if (value & 1) {
+          modifiers.push(tokenModifierLegend[index])
+        }
+        value = value >> 1
+        index += 1
+      }
+
+      const from = lineStart + character
+      const to = from + length
+      const decoration = plugin.client.config.highlightSemanticTokens!(
+        plugin,
+        from,
+        to,
+        tokenTypeLegend[tokenType],
+        modifiers,
+      )
+      builder.add(from, to, decoration)
+    }
+    view.dispatch({effects: [semanticTokensEffect.of(builder.finish())]})
+  }
+
+  destroy() {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+  }
+})
+
+const semanticTokensState = StateField.define<DecorationSet | null>({
+  create() {
+    return null
+  },
+  update(decorations, tr) {
+    for (let e of tr.effects) if (e.is(semanticTokensEffect)) {
+      decorations = e.value
+    }
+    if (decorations && tr.docChanged) {
+      return decorations.map(tr.changes)
+    }
+    return decorations
+  },
+  provide: f => EditorView.decorations.from(f, set => set ?? Decoration.none),
+})
+
+const semanticTokensEffect = StateEffect.define<DecorationSet>({})
+
+export function semanticTokens(): Extension {
+  return [
+    semanticTokensState,
+    semanticTokensPlugin,
+  ]
+}


### PR DESCRIPTION
This adds support for highlighting using LSP [semantic tokens](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens). This feature must be enabled manually by implementing `LSPClientConfig.highlightSemanticTokens` which is where to specify how semantic tokens should be translated to codemirror decorations.

Updates are debounced to avoid requesting semantic tokens on every text edit and could also support client side cancellation in theory (more on that in the code comment). The implementation only really supports `textDocument/semanticTokens/full` but will fall back to requesting `textDocument/semanticTokens/range` on the entire document if unavailable. 
